### PR TITLE
Global CSS set

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -1,0 +1,64 @@
+/*Reset*/
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/*Rootvariables for colours*/
+:root {
+  --colour-primary: #796eff;
+  --colour-primary-tint: #f6f3fc;
+  --colour-text-headings: #35414b;
+  --colour-text-body: #4e5a65;
+  --colour-background: #fbfafe;
+  --colour-background-footer: #1d2830;
+}
+
+/*Typography for mobile site*/
+html {
+  font-size: 16px;
+  line-height: 1.5rem;
+  font-family: "Inter", "Arial", sans-serif;
+  background-color: var(--colour-background);
+  color: var(--colour-text-body);
+}
+
+h1 {
+  font-size: 2rem;
+  line-height: 2.5rem;
+  font-weight: 600;
+}
+
+h2 {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  font-weight: 600;
+}
+
+h3 {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: 600;
+}
+
+.container dark {
+  background-color: var(--colour-primary-tint);
+}
+
+/*Font sizes for desktop*/
+
+@media only screen and (min-width: 1000px) {
+  h1 {
+    font-size: 4rem;
+    line-height: 4.75rem;
+  }
+  h2 {
+    font-size: 2.5rem;
+    line-height: 3rem;
+  }
+  h3 {
+    font-size: 1.75rem;
+    line-height: 2.25rem;
+  }
+}


### PR DESCRIPTION
Added:

- CSS basic reset (border box, zero margin and padding).
- Created variables for all the colours, names as per the Assets- Colours brief.
- Set typography, as per the Assest - Typography brief, prioritising mobile first and with inclusion of media queries for desktop font that sets in for screens over 1000px wide.
- All sizes are set in rem with 1 rem = 16px (the size of p text on both desktop and mobile), so this can be used on other CSS sheets.
- Set a background colour for '.container dark' which can be auto added to all containers with the darker background colour.  I have not defined the wider container class at this point (e.g. width etc) so this may need coming back to once we've started working on them.