### PR TITLE
CSS for Home>Facts. Mobile and Desktop

### DIFF
--- a/assets/css/home/facts.css
+++ b/assets/css/home/facts.css
@@ -1,2 +1,64 @@
 #facts {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  margin: 0 auto;
+  padding: 1rem;
+  width: 90%;
+}
+
+.facts_container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  padding: 1rem;
+  margin: 0 auto;
+}
+
+.quick_fact {
+  padding: 1rem;
+}
+
+#facts img {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.hide1 {
+  display: none;
+}
+
+button {
+  width: 50%;
+  margin: 0 auto;
+  padding: 0.5rem;
+  border: none;
+  border-radius: 5px;
+  color: #796eff;
+  font-weight: 550;
+  background-color: #796eff40;
+}
+
+@media only screen and (min-width: 1000px) {
+  .hide2 {
+    display: none;
+  }
+  .hide1 {
+    display: block;
+  }
+  .facts1 {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  .facts2 {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  .quick_fact {
+    max-width: 20%;
+  }
 }

--- a/assets/css/home/home.css
+++ b/assets/css/home/home.css
@@ -4,3 +4,10 @@
 @import "vip.css";
 @import "reviews.css";
 @import "reviews.css";
+
+main {
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  width: 90%;
+}

--- a/index.html
+++ b/index.html
@@ -30,42 +30,46 @@
       <section id="facts">
         <h2>What we do</h2>
         <div class="facts_container">
-          <div class="quick_fact">
-            <img src="./assets/imgs/menu.png" />
-            <h3>Varied menu</h3>
-            <p>With dishes from over 42 star systems!</p>
+          <div class="facts1">
+            <div class="quick_fact">
+              <img src="./assets/imgs/menu.png" />
+              <h3>Varied menu</h3>
+              <p>With dishes from over 42 star systems!</p>
+            </div>
+            <div class="quick_fact">
+              <img src="./assets/imgs/destination.png" />
+              <h3>794 lightyears</h3>
+              <p>From the Tadpole Galaxy.</p>
+            </div>
+            <div class="quick_fact">
+              <img src="./assets/imgs/ai.png" />
+              <h3>Can't decide?</h3>
+              <p>Try out our AI dish picker.</p>
+            </div>
           </div>
-          <div class="quick_fact">
-            <img src="./assets/imgs/destination.png" />
-            <h3>794 lightyears</h3>
-            <p>From the Tadpole Galaxy.</p>
+          <div class="facts2">
+            <div class="quick_fact hide1">
+              <img src="./assets/imgs/fast-food.png" />
+              <h3>Food fabricator</h3>
+              <p>
+                Put a morsel of your favourite dish in our food fabricator for a
+                taste of home.
+              </p>
+            </div>
+            <div class="quick_fact hide1">
+              <img src="./assets/imgs/destination.png" />
+              <h3>922 light years</h3>
+              <p>From the Andromeda Galaxy.</p>
+            </div>
+            <div class="quick_fact hide1">
+              <img src="./assets/imgs/ai.png" />
+              <h3>Feeling shy?</h3>
+              <p>
+                Request one of our AI waiters and enjoy your evening in peace.
+              </p>
+            </div>
           </div>
-          <div class="quick_fact">
-            <img src="./assets/imgs/ai.png" />
-            <h3>Can't decide?</h3>
-            <p>Try out our AI dish picker.</p>
-          </div>
-          <div class="quick_fact hide1">
-            <img src="./assets/imgs/fast-food.png" />
-            <h3>Food fabricator</h3>
-            <p>
-              Put a morsel of your favourite dish in our food fabricator for a
-              taste of home.
-            </p>
-          </div>
-          <div class="quick_fact hide1">
-            <img src="./assets/imgs/destination.png" />
-            <h3>922 light years</h3>
-            <p>From the Andromeda Galaxy.</p>
-          </div>
-          <div class="quick_fact hide1">
-            <img src="./assets/imgs/ai.png" />
-            <h3>Feeling shy?</h3>
-            <p>
-              Request one of our AI waiters and enjoy your evening in peace.
-            </p>
-          </div>
-          <button class="hide2p">View More</button>
+          <button class="hide2">View More</button>
         </div>
       </section>
       <section id="vip">

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         <div class="footer-company">
           <h3>Company</h3>
           <div class="hide1">
-            /*added div so will hide on mobile*/
+            <!--added div so will hide on mobile-->
             <a href="./about/index.html">About Us</a> <br />
             <a href="./about/index.html">Contact Us</a>
           </div>
@@ -92,7 +92,7 @@
         <div class="footer-legal">
           <h3>Legal</h3>
           <div class="hide1">
-            /*added div so will hide on mobile*/
+            <!--added div so will hide on mobile-->
             <a
               href="https://github.com/technative-academy/milliways_restaurant/blob/main/credits.md"
               >Credits and Attributions</a
@@ -115,6 +115,7 @@
           >
         </span>
         <div class="footer-socials hide1">
+          <!--added div so will hide on mobile-->
           <a
             class="social-icon"
             target="_blank"


### PR DESCRIPTION
Added CSS for Home>Facts Section.

**facts.css**
Mobile first design:
- flexbox created on section conatining heading and facts_container elements, set to column.
- flexbox created on facts_container element containing facts1 and facts2 elements (containing quick_facts 1-3 and 4-6, respectively), set to column.
- quick_facts 4-6 set to hide using .hide1 class
- buttonflat design features.  Currently no hover or visited designs.  I'll add to the backlog.

Desktop design:
- media query for screens over 1000px
- changed display on hide1 and hide2.
- facts1 and facts2 set to flex row display for quick_fact elements, with space-between justification.
- set max width for the quick_facts elements so they don't take up the whole screen width.

General element padding set to 1rem.

**home.css**
- set up basic flex box for the page

**index.html**
- added divs facts1 and facts2 to split the quick_facts elements to help create two rows for the desktop view.