### PR TITLE
about page css

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../assets/css/about/about.css" />
   </head>
   <body>
-    <header>
+    <header class="background">
       <p>Milliways</p>
       <nav>
         <ul>
@@ -20,7 +20,9 @@
     </header>
     <main>
       <h1>About Milliways</h1>
-      <p id="outside">Taking you to the end of space while you've still got the time!</p>
+      <p id="outside">
+        Taking you to the end of space while you've still got the time!
+      </p>
       <section id="blurb">
         <div>
           <h2>A home for one, a home for all.</h2>
@@ -44,7 +46,7 @@
         </figure>
       </section>
 
-      <section id="contact">
+      <section id="contact" class="background">
         <div class="contact-container">
           <div class="map">
             <img

--- a/about/index.html
+++ b/about/index.html
@@ -20,7 +20,7 @@
     </header>
     <main>
       <h1>About Milliways</h1>
-      <p>Taking you to the end of space while you've still got the time!</p>
+      <p id="outside">Taking you to the end of space while you've still got the time!</p>
       <section id="blurb">
         <div>
           <h2>A home for one, a home for all.</h2>

--- a/assets/css/about/about.css
+++ b/assets/css/about/about.css
@@ -4,12 +4,11 @@
 main {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
 }
 
 main h1 {
   text-align: center;
-  padding: 1rem;
+  padding: 2rem;
 }
 
 #outside {
@@ -21,4 +20,8 @@ main h1 {
     max-width: 80%;
     margin: 0 auto;
   }
+}
+
+.background {
+  background-color: #f6f3fc;
 }

--- a/assets/css/about/about.css
+++ b/assets/css/about/about.css
@@ -1,11 +1,24 @@
 @import "blurb.css";
 @import "contact.css";
 
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
 main h1 {
   text-align: center;
   padding: 1rem;
 }
 
-main p {
+#outside {
   text-align: center;
+}
+
+@media only screen and (min-width: 1000px) {
+  main {
+    max-width: 80%;
+    margin: 0 auto;
+  }
 }

--- a/assets/css/about/blurb.css
+++ b/assets/css/about/blurb.css
@@ -2,12 +2,12 @@
   max-width: 100%;
   display: flex;
   flex-direction: column;
-  padding: 1rem;
+  gap: 2rem;
 }
 
 #blurb div {
   margin: 0 auto;
-  text-align: center;
+  text-align: left;
   padding: 1rem;
 }
 
@@ -16,7 +16,7 @@
 }
 
 #blurb img {
-  max-width: 80%;
+  max-width: 100%;
   border-radius: 1rem;
 }
 
@@ -27,7 +27,6 @@
 @media only screen and (min-width: 1000px) {
   #blurb {
     flex-direction: row;
-    max-width: 80%;
     margin: 0 auto;
   }
 

--- a/assets/css/about/blurb.css
+++ b/assets/css/about/blurb.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  padding: 2rem;
 }
 
 #blurb div {

--- a/assets/css/about/contact.css
+++ b/assets/css/about/contact.css
@@ -1,18 +1,19 @@
 #contact {
   display: flex;
+  gap: 2rem;
 }
 h2 {
   margin-bottom: 10px;
 }
 .contact-container {
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   justify-content: space-between;
-  padding: 20px;
+  padding: 1rem;
 }
 
 .map img {
-  width: 70%;
+  width: 100%;
   border-radius: 6%;
 }
 form {
@@ -21,7 +22,7 @@ form {
 }
 
 .form-contact-container {
-  width: 70%;
+  padding: 1rem;
 }
 
 input[type="text"],
@@ -50,8 +51,14 @@ input[type="submit"]:hover {
 }
 
 @media only screen and (min-width: 1000px) {
+  #contact {
+    justify-content: space-between;
+  }
   .contact-container {
     display: flex;
     flex-direction: row;
+  }
+  .map img {
+    max-width: 90%;
   }
 }

--- a/assets/css/about/contact.css
+++ b/assets/css/about/contact.css
@@ -1,6 +1,7 @@
 #contact {
   display: flex;
   gap: 2rem;
+  padding: 2rem;
 }
 h2 {
   margin-bottom: 10px;


### PR DESCRIPTION
**Changes Guide**

I have added a flex box to the about.css file so I can implement a gap between sections.  This probably wants adding to home.css too.

Tweaked some properties across about.css and contact.css to ensure the internal styling of the block matches up as much as possible.

Gave the p in element loose in main an id of "outside" (it's outside a section) so that I could style that without other p's in main inheriting the same formatting.

**Testing**
Would benefit from being seen on a extra large screen.  I'm hoping the max-width (which could be moved to global or else will need replicating on home.css) will help, but I can only see so wide!

**Recommendations for additions to backlog:**
- Review header size
- Contact form button could be swapped to purple to follow design spec.  There's another button already on home index.html following this convention, which equally could be swapped to the green if we'd rather that design style. Would be nice to have the same conventions across the site and will make creating :hover etc much easier down the line :)

**Trello Link**

https://trello.com/c/Fd0cLLLB